### PR TITLE
[cairo] Build with Meson, Update to 1.17.8

### DIFF
--- a/rpm/cairo-1.17.8-ft-font-missing-glyph.patch
+++ b/rpm/cairo-1.17.8-ft-font-missing-glyph.patch
@@ -1,0 +1,61 @@
+From 2766d9feeccd5d66e346b0abab38726b8e0aa1e9 Mon Sep 17 00:00:00 2001
+From: Adrian Johnson <ajohnson@redneon.com>
+Date: Tue, 7 Mar 2023 19:40:21 +1030
+Subject: [PATCH] ft: Use normal font size when detecting the format
+
+The format may depend on the font size.
+
+Fixes #643
+---
+ src/cairo-ft-font.c | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/src/cairo-ft-font.c b/src/cairo-ft-font.c
+index 22a6a622b..89af6193d 100644
+--- a/src/cairo-ft-font.c
++++ b/src/cairo-ft-font.c
+@@ -3314,11 +3314,13 @@ _cairo_ft_scaled_glyph_init_metrics (cairo_ft_scaled_font_t  *scaled_font,
+     if (scaled_font->unscaled->have_color && scaled_font->base.options.color_mode != CAIRO_COLOR_MODE_NO_COLOR)
+ 	color_flag = FT_LOAD_COLOR;
+ #endif
++    /* Ensure use_em_size = FALSE as the format (bitmap or outline)
++     * may change with the size. */
+     status = _cairo_ft_scaled_glyph_load_glyph (scaled_font,
+ 						scaled_glyph,
+ 						face,
+ 						load_flags | color_flag,
+-						!hint_metrics,
++						FALSE,
+ 						vertical_layout);
+     if (unlikely (status))
+ 	return status;
+@@ -3344,6 +3346,18 @@ _cairo_ft_scaled_glyph_init_metrics (cairo_ft_scaled_font_t  *scaled_font,
+ 	 glyph_priv->format =  CAIRO_FT_GLYPH_TYPE_BITMAP;
+     }
+ 
++    /* If hinting is off, load the glyph with font size set the the em size. */
++    if (!hint_metrics) {
++	status = _cairo_ft_scaled_glyph_load_glyph (scaled_font,
++						    scaled_glyph,
++						    face,
++						    load_flags | color_flag,
++						    TRUE,
++						    vertical_layout);
++	if (unlikely (status))
++	    return status;
++    }
++
+     _cairo_ft_scaled_glyph_get_metrics (scaled_font,
+ 					face,
+ 					vertical_layout,
+@@ -3369,6 +3383,7 @@ _cairo_ft_scaled_glyph_init_metrics (cairo_ft_scaled_font_t  *scaled_font,
+     }
+ 
+     if (glyph_priv->format == CAIRO_FT_GLYPH_TYPE_COLR_V1) {
++	/* Restore font size if previously loaded at em_size. */
+ 	if (!hint_metrics) {
+ 	    status = _cairo_ft_scaled_glyph_load_glyph (scaled_font,
+ 							scaled_glyph,
+-- 
+GitLab
+


### PR DESCRIPTION
I was bored and wanted to learn... and accidentally put some time into this such that even if i wasn't very efficient it might save you some time.
(This update is not something i need/want... purely done for fun)

Rumor has it they will be Meson-only from 1.18 and forward.
It did not build on current version, so updated to latest along with changing build system, which perhaps ideally should have been two steps.

NB: i have not dared to test this yet.

Summary of diff:

```
-Version:    1.17.4
+Version:    1.17.8
```
...and the submodule.
This did not work on 1.17.4... so stepped to latest.

```
-BuildRequires:  pkgconfig(pixman-1) >= 0.30.0
+BuildRequires:  pkgconfig(pixman-1) >= 0.36.0
```
Stolen from Fedora. We satisfy it.

`-BuildRequires:  pkgconfig(libxml-2.0)`
SVG backend no longer needs this, since 1.1.10 - and xml backend removed.

```
-BuildRequires:  libGLESv2-devel
-BuildRequires:  libEGL-devel
```
Gl backend removed.

`-BuildRequires:  binutils-devel`
See symbol-lookup below. 

`+BuildRequires:  meson`
Obviously...

`+BuildRequires:  ccache`
Meson/ninja seems to want it. It just worked.
```

-%autogen --disable-static \
-    --disable-xlib \
-    --enable-ps \
-    --enable-pdf \
-    --enable-svg \
-    --enable-tee \
-    --enable-xml \
-    --enable-gobject \
-    --enable-glesv3 \
-    --disable-gtk-doc
+%meson \
+    -Dxlib=disabled \
+    -Dxcb=disabled \
+    -Dglib=enabled \
+    -Dgtk_doc=false \
+    -Dtests=disabled \
+    -Dtee=disabled \
+    -Dsymbol-lookup=disabled \
+    -Dspectre=disabled \
+    -Dfreetype=enabled \
+    -Dfontconfig=enabled \
+    -Dzlib=enabled \
+    -Dpng=enabled
```

`--disable-xlib` -> `-Dxlib=disabled`
`-Dxcb=disabled` Some other X11 dependency to disable
`--enable-ps/pdf/svg` Are enabled always it seems, and i can't see any "redundant" switches to use to guard against that changing.
`--enable-xml` Removed (even if there is a Dxml in this version) since it has since been removed upstream.
`--enable-gobject` -> `-Dglib=enabled` presumably.
`--enable-glesv3` Removed. gles backend is removed upstream.
`--disable-gtk-doc` -> `-Dgtk_doc=false`

Now comes the iffy one:
`-Dtee=disabled `
This is broken in 1.17.8, and Cairo devs seems to think it is not much used.
Fedora has it enabled; but do we care about tee, aka flight data recorder aka fdr?

Somewhat well-founded guesswork:
`-Dsymbol-lookup=disabled`
Build fails with no reference to binutils bfd_openr
This is the (only afaict) dependency to binutils, removed above.
Not enabled in Fedora either. Do we use it?
Some mumblings about this being a Meson bug fixed in a few versions. Using 1.0 did not help for me.

`-Dspectre=disabled`
Ghostscript libspectre for rendering Postscript.
Not enabled in Fedora either. I don't think you depended on this before, nor have ghostscript.

Additions:
`-Dfreetype=enabled`, `-Dfontconfig=enabled` Clear dependencies. Fedora does this.
`-Dzlib=enabled`, `-Dpng=enabled` Looked through what options there are. These we obviously want.


Fedora spec for reference: https://src.fedoraproject.org/rpms/cairo/blob/rawhide/f/cairo.spec

files:
`-%{_libdir}/cairo/cairo*.so*`
After removing tee/fdr, there is only libcairo-trace.so here.
Also note that nothing matches cairo*.so.* with a trailing dot.

devel:
`-%{_libdir}/cairo/cairo*.so*`
Same.

NB that libcairo-trace.so is excluded in the trace package itself.
No idea why.